### PR TITLE
EnemyControlFix

### DIFF
--- a/Assets/Source/Scripts/Constructions/ConstructionSelector.cs
+++ b/Assets/Source/Scripts/Constructions/ConstructionSelector.cs
@@ -18,7 +18,7 @@ namespace BugStrategy.Constructions
             _constructionGrid = constructionGrid;
         }
 
-        public bool TrySelect(Ray ray)
+        public bool TrySelect(Ray ray, AffiliationEnum playerAffiliation)
         {
             if (Physics.Raycast(ray, out RaycastHit hitInfo, 50f, CustomLayerID.Construction_Ground.Cast<int>()))
             {
@@ -26,6 +26,15 @@ namespace BugStrategy.Constructions
 
                 if (_constructionGrid.ConstructionExist(position))
                 {
+                    var construction = _constructionGrid.GetConstruction(position);
+#if !UNITY_EDITOR
+                    if (construction.Affiliation != playerAffiliation)
+                    {
+                        ResetSelection();
+                        return false;
+                    }
+#endif
+
                     LastSelectedConstruction = SelectedConstruction;
                     SelectedConstruction = _constructionGrid.GetConstruction(position);
                     OnSelectionChange?.Invoke();

--- a/Assets/Source/Scripts/Core/Selection/Selector.cs
+++ b/Assets/Source/Scripts/Core/Selection/Selector.cs
@@ -52,7 +52,7 @@ namespace BugStrategy.Selection
                 {
                     _missionData.ConstructionSelector.ResetSelection();
                     _unitsSelector.DeselectAll();
-                    if (_unitsSelector.SelectUnits(StartSelectPoint, CurrentSelectPoint))
+                    if (_unitsSelector.SelectUnits(StartSelectPoint, CurrentSelectPoint, _missionData.PlayerAffiliation))
                         _uiController.SetScreen(_unitsSelector.GetSelectedUnits()[0]);
                     else
                         _uiController.SetScreen(UIScreenType.Gameplay);
@@ -61,7 +61,7 @@ namespace BugStrategy.Selection
                 {
                     var ray = Camera.main.ScreenPointToRay(_inputProvider.MousePosition);
                     
-                    if (_missionData.ConstructionSelector.TrySelect(ray))
+                    if (_missionData.ConstructionSelector.TrySelect(ray, _missionData.PlayerAffiliation))
                     {
                         var selectedConstruction = _missionData.ConstructionSelector.SelectedConstruction;
                         selectedConstruction.Select();
@@ -70,7 +70,7 @@ namespace BugStrategy.Selection
                     else
                     {
                         _unitsSelector.DeselectAll();
-                        if (_unitsSelector.SelectUnits(StartSelectPoint, CurrentSelectPoint))
+                        if (_unitsSelector.SelectUnits(StartSelectPoint, CurrentSelectPoint, _missionData.PlayerAffiliation))
                             _uiController.SetScreen(_unitsSelector.GetSelectedUnits()[0]);
                         else
                             _uiController.SetScreen(UIScreenType.Gameplay);

--- a/Assets/Source/Scripts/Unit/UnitSelection/UnitsSelector.cs
+++ b/Assets/Source/Scripts/Unit/UnitSelection/UnitsSelector.cs
@@ -14,7 +14,7 @@ namespace BugStrategy.Unit.UnitSelection
 
         public event Action OnSelectionChanged;
 
-        public bool SelectUnits(Vector3 selectedStartPoint, Vector3 selectedEndPoint)
+        public bool SelectUnits(Vector3 selectedStartPoint, Vector3 selectedEndPoint, AffiliationEnum playerAffiliation)
         {
             var startPoint = new Vector2(selectedStartPoint.x, selectedStartPoint.z);
             var endPoint = new Vector2(selectedEndPoint.x, selectedEndPoint.z);
@@ -30,6 +30,12 @@ namespace BugStrategy.Unit.UnitSelection
             var anyUnit = false;
             foreach (var unit in UnitsInScreen)
             {
+#if !UNITY_EDITOR
+                if (unit.Affiliation != playerAffiliation)
+                {
+                    continue;
+                }
+#endif
                 var unitCoordinate = new Vector2(unit.transform.position.x, unit.transform.position.z);
 
                 if (CheckSelectionBounds(unitCoordinate, startPoint, endPoint))


### PR DESCRIPTION
Теперь выделить вражеских юнитов и здания нельзя именно в билде, в редакторе всё работает. Делал через #if !UNITY_EDITOR  #endif. 